### PR TITLE
Avoid excessive symbol creation

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -13,7 +13,7 @@ module Rumoji
 
   # Transform a cheat-sheet code into an Emoji
   def decode(str)
-    str.gsub(/:([^\s:]?[\w-]+):/) {|sym| (Emoji.find($1.intern) || sym).to_s }
+    str.gsub(/:([^\s:]?[\w-]+):/) { |match| (Emoji.find($1) || match).to_s }
   end
 
   def encode_io(readable, writeable=StringIO.new(""))

--- a/lib/rumoji/emoji.rb
+++ b/lib/rumoji/emoji.rb
@@ -12,7 +12,11 @@ module Rumoji
     end
 
     def symbol
-      @cheat_codes.first
+      symbols.first
+    end
+
+    def symbols
+      @cheat_codes
     end
 
     def code
@@ -20,7 +24,7 @@ module Rumoji
     end
 
     def include?(symbol)
-      @cheat_codes.map(&:to_s).include? symbol.to_s
+      symbols.map(&:to_s).include? symbol.to_s
     end
 
     def to_s
@@ -53,11 +57,14 @@ module Rumoji
 
     ALL_REGEXP = Regexp.new(ALL.map(&:string).join('|'))
 
-    FIND_BY_SYMBOL_CACHE = {}
+    SYMBOL_LOOKUP = ALL.each.with_object({}) do |emoji, lookup|
+      emoji.symbols.each do |symbol|
+        lookup[symbol.to_s] = emoji
+      end
+    end
 
     def self.find(symbol)
-      symbol = symbol.to_s
-      FIND_BY_SYMBOL_CACHE[symbol] ||= ALL.find { |emoji| emoji.include? symbol }
+      SYMBOL_LOOKUP[symbol.to_s]
     end
 
     STRING_LOOKUP = ALL.each.with_object({}) do |emoji, lookup|

--- a/lib/rumoji/emoji.rb
+++ b/lib/rumoji/emoji.rb
@@ -20,7 +20,7 @@ module Rumoji
     end
 
     def include?(symbol)
-      @cheat_codes.include? symbol.to_sym
+      @cheat_codes.map(&:to_s).include? symbol.to_s
     end
 
     def to_s
@@ -53,8 +53,11 @@ module Rumoji
 
     ALL_REGEXP = Regexp.new(ALL.map(&:string).join('|'))
 
+    FIND_BY_SYMBOL_CACHE = {}
+
     def self.find(symbol)
-      ALL.find {|emoji| emoji.include? symbol }
+      symbol = symbol.to_s
+      FIND_BY_SYMBOL_CACHE[symbol] ||= ALL.find { |emoji| emoji.include? symbol }
     end
 
     STRING_LOOKUP = ALL.each.with_object({}) do |emoji, lookup|

--- a/spec/rumoji/emoji_spec.rb
+++ b/spec/rumoji/emoji_spec.rb
@@ -62,8 +62,12 @@ describe Rumoji::Emoji do
     let(:smile_str) { "\u{1F604}" }
     let(:smile_sym) { :smile }
 
-    it "finds an emoji from cheat sheet code" do
+    it "finds an emoji from cheat sheet code symbol" do
       subject.find(smile_sym).to_s.must_equal smile_str
+    end
+
+    it "finds an emoji from cheat sheet code string" do
+      subject.find(smile_sym.to_s).to_s.must_equal smile_str
     end
 
     it "finds an emoji from a string" do


### PR DESCRIPTION
Creating symbols from user input strings can cause memory exhaustion in Ruby versions before 2.2 (2.2 supports garbage collection of symbols; prior versions did not). This change avoids creating symbols for every string that we try to find an Emoji for, and it also adds a lookup hash to speed up decoding (now 25-35x faster, depending on what cheat codes are used).
